### PR TITLE
Release/v 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+* **BREAKING** - Changed `ApiRequest` typedef to be a `Function` instead of a `Future` (impacts `ApiCallBuilder` widget)
+* Added method to trigger API call again for `SingleApiCallCubit`
+* Added _child_ parameter to `ApiCallBuilder` widget
+
 ## 1.1.9
 Added `client` parameter to `ConnectionManager` constructor to eventually override the default http client for API calls.
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ PostApiResponse<User, GenericError>(
 ```
 
 ### ApiCallBuilder
-To easily integrate a widget that does an API call in your widget tree, you can use `ApiCallBuilder`. It's a widget that using bloc shows a loader while performing the provided API call and then returns the response in a builder that must return the widget to show on completion. The `ApiCallBuilder` must be together with the `ConnectionManager` as it accept as input the `doApiRequest` method as shown below.
+To easily integrate a widget that does an API call in your widget tree, you can use `ApiCallBuilder`. It's a widget that using bloc shows a loader while performing the provided API call and then returns the response in a builder that must return the widget to show on completion. The `ApiCallBuilder` must be used together with the `ConnectionManager` as it accept as input the `doApiRequest` method as shown below.
 
  ``` dart
  ApiCallBuilder<User, Error>(
-   apiCall: context.read<NetworkProvider>().doApiRequest(
+   apiCall: () => context.read<NetworkProvider>().doApiRequest(
      requestType: ApiRequestType.get,
      endpoint: "/test-endpoint",
    ),
@@ -214,6 +214,14 @@ To easily integrate a widget that does an API call in your widget tree, you can 
    emptyDataBuilder: (context) => Text("No data"),  /// Optional, a widget to manage the empty state can be provided. If not provided, the `builder` will be used
  );
  ```
+
+As soon as the widget is created, the api call is triggered. If you want to trigger the API call again, simply call:
+
+``` dart
+  context.read<SingleApiCallCubit<Decodable,Decodable>>().startApiCall();
+```
+
+Note that you can specify a `child` argument to always show some widgets while data is loading. Check the documentation for further details.
 
  ### PaginatedApiCallBuilder
 To manage transparently a paginated API call in the widget tree, you can use `PaginatedApiCallBuilder`. It shows a loading widget while performing the request and provides access to the response in the `builder` parameter, to show a proper widget on http call completion. Furthermore, it can manage pagination while scrolling.

--- a/lib/connection_manager.dart
+++ b/lib/connection_manager.dart
@@ -10,6 +10,7 @@ export 'base_connection_manager.dart';
 export 'connection_manager_stub.dart';
 export 'src/data/models/api_response.dart';
 export 'src/logic/cubit/paginated_api_call/paginated_api_call_cubit.dart';
+export 'src/logic/cubit/single_api_call/single_api_call_cubit.dart';
 
 import 'dart:convert';
 import 'base_connection_manager.dart';
@@ -34,7 +35,7 @@ typedef PaginatedAPIRequest<T extends Decodable, E extends Decodable>
         int page, Map<String, String>? query);
 
 typedef APIRequest<T extends Decodable, E extends Decodable>
-    = Future<APIResponse<T, E>>;
+    = Future<APIResponse<T, E>> Function();
 
 /// Class to manage API and network calls. It can be instantiated as a singleton
 /// to use a single instance of it all through the app.

--- a/lib/src/logic/cubit/single_api_call/single_api_call_cubit.dart
+++ b/lib/src/logic/cubit/single_api_call/single_api_call_cubit.dart
@@ -7,14 +7,19 @@ part 'single_api_call_state.dart';
 
 class SingleApiCallCubit<T extends Decodable, E extends Decodable>
     extends Cubit<SingleApiCallState> {
-  final APIRequest<T, E> apiCall;
-  SingleApiCallCubit({required this.apiCall}) : super(ApiCallInitialState());
+  APIRequest<T, E> apiCall;
+  SingleApiCallCubit({required this.apiCall}) : super(ApiCallInitialState()) {
+    startApiCall();
+  }
 
   APIResponse<T, E>? response;
 
-  void startApiCall() async {
+  void startApiCall({APIRequest<T, E>? newApiCall}) async {
+    if (newApiCall != null) {
+      apiCall = newApiCall;
+    }
     emit(ApiCallLoadingState());
-    var res = await apiCall;
+    var res = await apiCall();
     response = res;
     if (res.hasError) {
       emit(ApiCallErrorState(errorMessage: res.message));

--- a/lib/src/ui/api_call_builder.dart
+++ b/lib/src/ui/api_call_builder.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../connection_manager.dart';
-import '../logic/cubit/single_api_call/single_api_call_cubit.dart';
 import '../ui/error_box.dart';
 import 'loader.dart';
 
@@ -22,6 +21,9 @@ class ApiCallBuilder<T extends Decodable, E extends Decodable>
   /// The api call to perform with the [ConnectionManager]. It is the same apicall
   /// with [doApiRequest] that is normally performmed by the [ConnectionManager]
   final APIRequest<T, E> apiCall;
+
+  /// Optionally, you can specify a [Widget] to not be involved in api calls rebuild
+  final Widget Function(Widget child)? child;
 
   /// The builder for a widget when the API call is successfull.
   /// The `response` argument is the class decoded by the [ConnectionManager].
@@ -66,6 +68,7 @@ class ApiCallBuilder<T extends Decodable, E extends Decodable>
     Key? key,
     required this.apiCall,
     required this.builder,
+    this.child,
     this.loaderBuilder,
     this.errorBuilder,
   }) : super(key: key);
@@ -74,33 +77,36 @@ class ApiCallBuilder<T extends Decodable, E extends Decodable>
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (context) => SingleApiCallCubit<T, E>(apiCall: apiCall),
-      child: BlocBuilder<SingleApiCallCubit<T, E>, SingleApiCallState>(
-        builder: (context, state) {
-          if (state is ApiCallInitialState) {
-            BlocProvider.of<SingleApiCallCubit<T, E>>(context).startApiCall();
-            if (loaderBuilder != null) {
-              return loaderBuilder!(context);
+      child: Builder(builder: (context) {
+        final blocBuilder =
+            BlocBuilder<SingleApiCallCubit<T, E>, SingleApiCallState>(
+          builder: (context, state) {
+            if (state is ApiCallInitialState) {
+              if (loaderBuilder != null) {
+                return loaderBuilder!(context);
+              }
+              return const LoaderWidget();
+            } else if (state is ApiCallLoadingState) {
+              if (loaderBuilder != null) {
+                return loaderBuilder!(context);
+              }
+              return const LoaderWidget();
+            } else if (state is ApiCallErrorState) {
+              if (errorBuilder != null) {
+                return errorBuilder!(context, state.errorMessage);
+              }
+              return ErrorBox(
+                errorMessage: state.errorMessage,
+              );
+            } else if (state is ApiCallLoadedState<T, E>) {
+              return builder(context, state.response.decodedBody,
+                  state.response.decodedBodyAsList);
             }
-            return const LoaderWidget();
-          } else if (state is ApiCallLoadingState) {
-            if (loaderBuilder != null) {
-              return loaderBuilder!(context);
-            }
-            return const LoaderWidget();
-          } else if (state is ApiCallErrorState) {
-            if (errorBuilder != null) {
-              return errorBuilder!(context, state.errorMessage);
-            }
-            return ErrorBox(
-              errorMessage: state.errorMessage,
-            );
-          } else if (state is ApiCallLoadedState<T, E>) {
-            return builder(context, state.response.decodedBody,
-                state.response.decodedBodyAsList);
-          }
-          return const ErrorBox();
-        },
-      ),
+            return const ErrorBox();
+          },
+        );
+        return child?.call(blocBuilder) ?? blocBuilder;
+      }),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connection_manager
 description: A simple connection manager to work with API and network calls
-version: 1.1.9
+version: 1.2.0
 homepage: "https://github.com/mobilesoftcode/connection_manager"
 issue_tracker: "https://github.com/mobilesoftcode/connection_manager/issues"
 

--- a/test/src/logic/cubit/single_api_call/single_api_call_cubit_test.dart
+++ b/test/src/logic/cubit/single_api_call/single_api_call_cubit_test.dart
@@ -1,6 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:connection_manager/connection_manager.dart';
-import 'package:connection_manager/src/logic/cubit/single_api_call/single_api_call_cubit.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,7 +8,7 @@ void main() {
   blocTest<SingleApiCallCubit, SingleApiCallState>(
     'emits [ApiCallLoadingState] and [ApiCallLoadedState] when startApiCall is called with success.',
     build: () => SingleApiCallCubit(
-        apiCall:
+        apiCall: () =>
             ConnectionManagerStub().doApiRequest(endpoint: "mocks/test.json")),
     act: (cubit) => cubit.startApiCall(),
     expect: () => [ApiCallLoadingState(), isA<ApiCallLoadedState>()],
@@ -18,7 +17,7 @@ void main() {
   blocTest<SingleApiCallCubit, SingleApiCallState>(
     'emits [ApiCallLoadingState] and [ApiCallErrorState] when startApiCall is called with error.',
     build: () => SingleApiCallCubit(
-        apiCall: ConnectionManagerStub(responseStatusCode: 500)
+        apiCall: () => ConnectionManagerStub(responseStatusCode: 500)
             .doApiRequest(endpoint: "mocks/test.json")),
     act: (cubit) => cubit.startApiCall(),
     expect: () => [ApiCallLoadingState(), isA<ApiCallErrorState>()],
@@ -27,7 +26,7 @@ void main() {
   blocTest<SingleApiCallCubit, SingleApiCallState>(
     'verify `response` is correct after startApiCall is called with success.',
     build: () => SingleApiCallCubit(
-        apiCall:
+        apiCall: () =>
             ConnectionManagerStub().doApiRequest(endpoint: "mocks/test.json")),
     act: (cubit) => cubit.startApiCall(),
     verify: (cubit) async {


### PR DESCRIPTION
* **BREAKING** - Changed `ApiRequest` typedef to be a `Function` instead of a `Future` (impacts `ApiCallBuilder` widget)
* Added method to trigger API call again for `SingleApiCallCubit`
* Added _child_ parameter to `ApiCallBuilder` widget