### PR TITLE
Increased version (1.2.0), updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+* **BREAKING** - Changed `ApiRequest` typedef to be a `Function` instead of a `Future` (impacts `ApiCallBuilder` widget)
+* Added method to trigger API call again for `SingleApiCallCubit`
+* Added _child_ parameter to `ApiCallBuilder` widget
+
 ## 1.1.9
 Added `client` parameter to `ConnectionManager` constructor to eventually override the default http client for API calls.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connection_manager
 description: A simple connection manager to work with API and network calls
-version: 1.1.9
+version: 1.2.0
 homepage: "https://github.com/mobilesoftcode/connection_manager"
 issue_tracker: "https://github.com/mobilesoftcode/connection_manager/issues"
 


### PR DESCRIPTION
* **BREAKING** - Changed `ApiRequest` typedef to be a `Function` instead of a `Future` (impacts `ApiCallBuilder` widget)
* Added method to trigger API call again for `SingleApiCallCubit`
* Added _child_ parameter to `ApiCallBuilder` widget